### PR TITLE
Re-arrange whois test calls to avoid failures

### DIFF
--- a/asyncwhois/query.py
+++ b/asyncwhois/query.py
@@ -82,7 +82,9 @@ class WhoIsQuery(Query):
                     with self._create_connection((self.server, self._whois_port), self.timeout) as conn:
                         # save output into "query_output"
                         self.query_output = self._send_and_recv(conn, data)
-
+        except ConnectionResetError:
+            server = self.server or self._iana_server
+            raise WhoIsQueryConnectError(f'"Connection reset by peer" when communicating with {server}:43')
         except socket.timeout:
             server = self.server or self._iana_server
             raise WhoIsQueryConnectError(f'Socket timed out when attempting to reach {server}:43')

--- a/tests/test_package_methods.py
+++ b/tests/test_package_methods.py
@@ -6,47 +6,27 @@ import asyncwhois
 class TestAsyncWhoIsQuery(asynctest.TestCase):
 
     async def test_aio_lookup(self):
-        test_domain = "google.com"
-        w = await asyncwhois.aio_lookup("google.com")
-        self.assertIn("domain name: google.com\n", w.query_output.lower())
-        self.assertEqual(w.parser_output.get('domain_name').lower(), test_domain)
-
-        test_domain = "comcast.net"
+        test_domain = "amazon.com"
         w = await asyncwhois.aio_lookup(test_domain)
-        self.assertIn("domain name: comcast.net\n", w.query_output.lower())
-        self.assertEqual(w.parser_output.get('domain_name').lower(), test_domain)
-
-    async def test_aio_whois_cmd_shell(self):
-        test_domain = "google.com"
-        w = await asyncwhois.aio_whois_cmd_shell("google.com")
-        self.assertIn("domain name: google.com\n", w.query_output.lower())
-        self.assertEqual(w.parser_output.get('domain_name').lower(), test_domain)
-
-        test_domain = "comcast.net"
-        w = await asyncwhois.aio_whois_cmd_shell(test_domain)
-        self.assertIn("domain name: comcast.net\n", w.query_output.lower())
+        self.assertIn(f"domain name: {test_domain}", w.query_output.lower())
         self.assertEqual(w.parser_output.get('domain_name').lower(), test_domain)
 
     def test_lookup(self):
-        test_domain = "google.com"
-        w = asyncwhois.lookup("google.com")
-        self.assertIn("domain name: google.com\n", w.query_output.lower())
+        test_domain = "elastic.co"
+        w = asyncwhois.lookup(test_domain)
+        self.assertIn(f"domain name: {test_domain}", w.query_output.lower())
         self.assertEqual(w.parser_output.get('domain_name').lower(), test_domain)
 
-        test_domain = "comcast.net"
-        w = asyncwhois.lookup(test_domain)
-        self.assertIn("domain name: comcast.net\n", w.query_output.lower())
+    async def test_aio_whois_cmd_shell(self):
+        test_domain = "yahoo.com"
+        w = await asyncwhois.aio_whois_cmd_shell(test_domain)
+        self.assertIn(f"domain name: {test_domain}", w.query_output.lower())
         self.assertEqual(w.parser_output.get('domain_name').lower(), test_domain)
 
     def test_whois_cmd_shell(self):
-        test_domain = "google.com"
-        w = asyncwhois.whois_cmd_shell("google.com")
-        self.assertIn("domain name: google.com\n", w.query_output.lower())
-        self.assertEqual(w.parser_output.get('domain_name').lower(), test_domain)
-
         test_domain = "comcast.net"
         w = asyncwhois.whois_cmd_shell(test_domain)
-        self.assertIn("domain name: comcast.net\n", w.query_output.lower())
+        self.assertIn(f"domain name: {test_domain}", w.query_output.lower())
         self.assertEqual(w.parser_output.get('domain_name').lower(), test_domain)
 
     def test_has_parser_support(self):


### PR DESCRIPTION
Running tests for the package methods is inconsistent because of the nature
of the whois servers and their respective cool-down rules. By re-arranging
TLDs in these tests, hopefully connections are more consistent