### PR TITLE
Add parser tests for 6 existing TLDs

### DIFF
--- a/asyncwhois/parser.py
+++ b/asyncwhois/parser.py
@@ -28,6 +28,7 @@ KNOWN_DATE_FORMATS = [
     '%d/%m/%Y %H:%M:%S',        # 23/04/2015 12:00:07 EEST
     '%d/%m/%Y %H:%M:%S %Z',     # 23/04/2015 12:00:07 EEST
     '%d/%m/%Y %H:%M:%S.%f %Z',  # 23/04/2015 12:00:07.619546 EEST
+    '%Y-%m-%d %H:%M:%S.%f',     # 23/04/2015 12:00:07.619546
     '%B %d %Y',                 # August 14 2017
     '%d.%m.%Y %H:%M:%S',        # 08.03.2014 10:28:24
     '%a %b %d %Y',              # Tue Dec 12 2000
@@ -557,7 +558,9 @@ class RegexDE(BaseParser):
     """
 
     _de_expressions = {
-        'updated': r'Changed: (\d{4}\.\s\d{2}\.\s\d{2}\.)'
+        'changed': r'Changed: (\d{4}\.\s\d{2}\.\s\d{2}\.)',
+        'name_servers': r'Nserver: *(.+)',
+        'domain_name': r'Domain: *(.+)'
     }
 
     def __init__(self):
@@ -1569,6 +1572,9 @@ class RegexNO(BaseParser):
     _no_expressions = {
         'created': r'Additional information:\nCreated:\s*(.+)',
         'updated': r'Additional information:\n(?:.*\n)Last updated:\s*(.+)',
+        'name_servers': r'Name Server Handle.........: *(.+)',
+        'registrar': r'Registrar Handle...........: *(.+)',
+        'domain_name': r'Domain Name................: *(.+)'
     }
 
     def __init__(self):

--- a/tests/samples/tld_ai.txt
+++ b/tests/samples/tld_ai.txt
@@ -1,0 +1,70 @@
+Domain Name: google.ai
+Registry Domain ID: 325702_nic_ai
+Registry WHOIS Server:: whois.nic.ai
+Updated Date: 2019-08-24T09:32:27.549Z
+Creation Date: 2017-12-16T05:37:20.801Z
+Registry Expiry Date: 2021-09-25T05:37:20.856Z
+Registrar Registration Expiration Date: 2021-09-25T05:37:20.856Z
+Registrar: Markmonitor
+Registrar Abuse Contact Email: ccops@markmonitor.com
+Registrar Abuse Contact Phone: +1.2083895740
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Registry Registrant ID: lMzTF-0Fv0m
+Registrant Name: Domain Administrator
+Registrant Organization: Google LLC
+Registrant Street: 1600 Amphitheatre Parkway
+Registrant City: Mountain View
+Registrant State/Province: CA
+Registrant Postal Code: 94043
+Registrant Country: US
+Registrant Phone: +1.6502530000
+Registrant Fax: +1.6502530001
+Registrant Email: dns-admin@google.com
+Registry Admin ID: ah0JN-CHGxZ
+Admin Name: Domain Administrator
+Admin Organization: Google LLC
+Admin Street: 1600 Amphitheatre Parkway
+Admin City: Mountain View
+Admin State/Province: CA
+Admin Postal Code: 94043
+Admin Country: US
+Admin Phone: +1.6502530000
+Admin Fax: +1.6502530001
+Admin Email: dns-admin@google.com
+Registry Tech ID: ag78m-wac5r
+Tech Name: Domain Administrator
+Tech Organization: Google LLC
+Tech Street: 1600 Amphitheatre Parkway
+Tech City: Mountain View
+Tech State/Province: CA
+Tech Postal Code: 94043
+Tech Country: US
+Tech Phone: +1.6502530000
+Tech Fax: +1.6502530001
+Tech Email: dns-admin@google.com
+Registry Billing ID: IqCa6-HLQms
+Billing Name: CCOPS Billing
+Billing Organization: MarkMonitor Inc.
+Billing Street: 3540 East Longwing Lane
+Billing Street: Suite 300
+Billing City: Meridian
+Billing State/Province: Idaho
+Billing Postal Code: 83646
+Billing Country: US
+Billing Phone: +1.2083895740
+Billing Fax: +1.2083895771
+Billing Email: ccopsbilling@markmonitor.com
+Name Server: ns3.zdns.google
+Name Server: ns4.zdns.google
+Name Server: ns1.zdns.google
+Name Server: ns2.zdns.google
+DNSSEC: unsigned
+>>> Last update of WHOIS database: 2020-08-22T14:04:47.385Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+TERMS OF USE: You are not authorized to access or query our WHOIS database through the use of electronic processes that are high-volume and automated.  THis WHOIS database is provided by as a service to the internet community.
+
+The data is for information purposes only. We do not guarantee its accuracy. By submitting a WHOIS query, you agree to abide by the following terms of use: You agree that you may use this Data only for lawful purposes and that under no circumstances will you use this Data to: (1) allow, enable, or otherwise support the transmission of mass unsolicited, commercial advertising or solicitations via e-mail, telephone, or facsimile; or (2) enable high volume, automated, electronic processes that apply to CoCCA it's members (or CoCCA or member computer systems). The compilation, repackaging, dissemination or other use of this Data is expressly prohibited.

--- a/tests/samples/tld_ar.txt
+++ b/tests/samples/tld_ar.txt
@@ -1,0 +1,31 @@
+% La información a la que estás accediendo se provee exclusivamente para
+% fines relacionados con operaciones sobre nombres de dominios y DNS,
+% quedando absolutamente prohibido su uso para otros fines.
+%
+% La DIRECCIÓN NACIONAL DEL REGISTRO DE DOMINIOS DE INTERNET es depositaria
+% de la información que los usuarios declaran con la sola finalidad de
+% registrar nombres de dominio en ‘.ar’, para ser publicada en el sitio web
+% de NIC Argentina.
+%
+% La información personal que consta en la base de datos generada a partir
+% del sistema de registro de nombres de dominios se encuentra amparada por
+% la Ley N° 25326 “Protección de Datos Personales” y el Decreto
+% Reglamentario 1558/01.
+
+domain:		google.ar
+registrant:	50037928906
+registrar:	nicar
+registered:	2019-11-01 12:21:37.677445
+changed:	2019-11-01 12:28:38.182736
+expire:		2020-11-01 00:00:00
+
+contact:	50037928906
+name:		GOOGLE INC.
+registrar:	nicar
+created:	2013-10-29 00:00:00
+changed:	2020-08-06 18:54:04.224566
+
+nserver:	ns1.markmonitor.com ()
+nserver:	ns3.markmonitor.com ()
+registrar:	nicar
+created:	2019-11-01 12:28:37.824369

--- a/tests/samples/tld_de.txt
+++ b/tests/samples/tld_de.txt
@@ -1,0 +1,24 @@
+% Restricted rights.
+%
+% Terms and Conditions of Use
+%
+% The above data may only be used within the scope of technical or
+% administrative necessities of Internet operation or to remedy legal
+% problems.
+% The use for other purposes, in particular for advertising, is not permitted.
+%
+% The DENIC whois service on port 43 doesn't disclose any information concerning
+% the domain holder, general request and abuse contact.
+% This information can be obtained through use of our web-based whois service
+% available at the DENIC website:
+% http://www.denic.de/en/domains/whois-service/web-whois.html
+%
+%
+
+Domain: google.de
+Nserver: ns1.google.com
+Nserver: ns2.google.com
+Nserver: ns3.google.com
+Nserver: ns4.google.com
+Status: connect
+Changed: 2018-03-12T21:44:25+01:00

--- a/tests/samples/tld_me.txt
+++ b/tests/samples/tld_me.txt
@@ -1,0 +1,34 @@
+Domain Name: GOOGLE.ME
+Registry Domain ID: D108500000000011599-AGRS
+Registrar WHOIS Server:
+Registrar URL: http://www.markmonitor.com
+Updated Date: 2020-05-12T09:36:44Z
+Creation Date: 2008-06-13T17:17:40Z
+Registry Expiry Date: 2021-06-13T17:17:40Z
+Registrar Registration Expiration Date:
+Registrar: MarkMonitor Inc.
+Registrar IANA ID: 292
+Registrar Abuse Contact Email:
+Registrar Abuse Contact Phone:
+Reseller:
+Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Domain Status: serverDeleteProhibited https://icann.org/epp#serverDeleteProhibited
+Domain Status: serverTransferProhibited https://icann.org/epp#serverTransferProhibited
+Domain Status: serverUpdateProhibited https://icann.org/epp#serverUpdateProhibited
+Registrant Organization: Google LLC
+Registrant State/Province: CA
+Registrant Country: US
+Name Server: NS1.GOOGLE.COM
+Name Server: NS2.GOOGLE.COM
+Name Server: NS4.GOOGLE.COM
+Name Server: NS3.GOOGLE.COM
+DNSSEC: unsigned
+URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2020-08-22T14:19:30Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+Access to WHOIS information is provided to assist persons in determining the contents of a domain name registration record in the registry database. The data in this record is provided by The Registry Operator for informational purposes only, and accuracy is not guaranteed.  This service is intended only for query-based access. You agree that you will use this data only for lawful purposes and that, under no circumstances will you use this data to (a) allow, enable, or otherwise support the transmission by e-mail, telephone, or facsimile of mass unsolicited, commercial advertising or solicitations to entities other than the data recipient's own existing customers; or (b) enable high volume, automated, electronic processes that send queries or data to the systems of Registry Operator, a Registrar, or Afilias except as reasonably necessary to register domain names or modify existing registrations. All rights reserved. Registry Operator reserves the right to modify these terms at any time. By submitting this query, you agree to abide by this policy.
+The Registrar of Record identified in this output may have an RDDS service that can be queried for additional information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.

--- a/tests/samples/tld_no.txt
+++ b/tests/samples/tld_no.txt
@@ -1,0 +1,35 @@
+% By looking up information in the domain registration directory
+% service, you confirm that you accept the terms and conditions of the
+% service:
+% https://www.norid.no/en/domeneoppslag/vilkar/
+%
+% Norid AS holds the copyright to the lookup service, content,
+% layout and the underlying collections of information used in the
+% service (cf. the Act on Intellectual Property of May 2, 1961, No.
+% 2). Any commercial % use of information from the service, including
+% targeted marketing, is prohibited. Using information from the domain
+% registration directory service in % violation of the terms and
+% conditions may result in legal prosecution.
+%
+% The whois service at port 43 is intended to contribute to resolving
+% technical problems where individual domains threaten the
+% functionality, security and stability of other domains or the
+% internet as an infrastructure. It does not give any information
+% about who the holder of a domain is. To find information about a
+% domain holder, please visit our website:
+% https://www.norid.no/en/domeneoppslag/
+
+Domain Information
+
+NORID Handle...............: GOO371D-NORID
+Domain Name................: google.no
+Registrar Handle...........: REG466-NORID
+Tech-c Handle..............: GL1R-NORID
+Name Server Handle.........: NSGO26H-NORID
+Name Server Handle.........: NSGO27H-NORID
+Name Server Handle.........: NSGO28H-NORID
+Name Server Handle.........: NSGO29H-NORID
+
+Additional information:
+Created:         2001-02-26
+Last updated:    2020-01-27

--- a/tests/samples/tld_us.txt
+++ b/tests/samples/tld_us.txt
@@ -1,0 +1,76 @@
+Domain Name: google.us
+Registry Domain ID: D775573-US
+Registrar WHOIS Server: whois.markmonitor.com
+Registrar URL: www.markmonitor.com
+Updated Date: 2020-03-22T10:31:37Z
+Creation Date: 2002-04-19T23:16:01Z
+Registry Expiry Date: 2021-04-18T23:59:59Z
+Registrar: MarkMonitor, Inc.
+Registrar IANA ID: 292
+Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+Registrar Abuse Contact Phone: +1.2083895740
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+Registry Registrant ID: C37454483-US
+Registrant Name: Google Inc
+Registrant Organization: Google LLC
+Registrant Street: 1600 Amphitheatre Parkway
+Registrant Street:
+Registrant Street:
+Registrant City: Mountain View
+Registrant State/Province: CA
+Registrant Postal Code: 94043
+Registrant Country: US
+Registrant Phone: +1.6502530000
+Registrant Phone Ext:
+Registrant Fax: +1.6502530001
+Registrant Fax Ext:
+Registrant Email: dns-admin@google.com
+Registrant Application Purpose: P1
+Registrant Nexus Category: C21
+Registry Admin ID: C37613731-US
+Admin Name: Christina Chiou
+Admin Organization: Google Inc.
+Admin Street: 1600 Amphitheatre Parkway
+Admin Street:
+Admin Street:
+Admin City: Mountain View
+Admin State/Province: CA
+Admin Postal Code: 94043
+Admin Country: US
+Admin Phone: +1.6502530000
+Admin Phone Ext:
+Admin Fax: +1.6502530001
+Admin Fax Ext:
+Admin Email: dns-admin@google.com
+Admin Application Purpose: P1
+Admin Nexus Category: C21
+Registry Tech ID: C37613731-US
+Tech Name: Christina Chiou
+Tech Organization: Google Inc.
+Tech Street: 1600 Amphitheatre Parkway
+Tech Street:
+Tech Street:
+Tech City: Mountain View
+Tech State/Province: CA
+Tech Postal Code: 94043
+Tech Country: US
+Tech Phone: +1.6502530000
+Tech Phone Ext:
+Tech Fax: +1.6502530001
+Tech Fax Ext:
+Tech Email: dns-admin@google.com
+Tech Application Purpose: P1
+Tech Nexus Category: C21
+Name Server: ns2.google.com
+Name Server: ns4.google.com
+Name Server: ns3.google.com
+Name Server: ns1.google.com
+DNSSEC: unsigned
+URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2020-08-22T00:55:50Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+Registry Services, LLC, the Registry Administrator for .US, has collected this information for the WHOIS database through a .US-Accredited Registrar. This information is provided to you for informational purposes only and is designed to assist persons in determining contents of a domain name registration record in the registry database. Registry Services, LLC makes this information available to you "as is" and does not guarantee its accuracy. By submitting a WHOIS query, you agree that you will use this data only for lawful purposes and that, under no circumstances will you use this data: (1) to allow, enable, or otherwise support the transmission of mass unsolicited, commercial advertising or solicitations via direct mail, electronic mail, or by telephone; (2) in contravention of any applicable data and privacy protection laws; or (3) to enable high volume, automated, electronic processes that apply to the registry (or its systems). Compilation, repackaging, dissemination, or other use of the WHOIS database in its entirety, or of a substantial portion thereof, is not allowed without our prior written permission. We reserve the right to modify or change these conditions at any time without prior or subsequent notification of any kind. By executing this query, in any manner whatsoever, you agree to abide by these terms. NOTE: FAILURE TO LOCATE A RECORD IN THE WHOIS DATABASE IS NOT INDICATIVE OF THE AVAILABILITY OF A DOMAIN NAME. All domain names are subject to certain additional domain name registration rules. For details, please visit our site at www.whois.us.

--- a/tests/test_parser_output.py
+++ b/tests/test_parser_output.py
@@ -272,3 +272,150 @@ class TestWhoIsParsers(unittest.TestCase):
         # registrant
         self.assertEqual(parser.parser_output.get("registrant_organization"), None)
         self.assertEqual(parser.parser_output.get("registrant_name"), None)
+
+    def test_parser_de(self):
+        query_output = self.get_txt('de')
+        parser = WhoIsParser('de')
+        parser.parse(query_output)
+
+        self.assertEqual(len(parser.parser_output.get('status')), 1)
+
+    def test_parse_us(self):
+        query_output = self.get_txt('us')
+        parser = WhoIsParser('us')
+        parser.parse(query_output)
+        # confirm dates
+        created_date = parser.parser_output.get("created")
+        updated_date = parser.parser_output.get("updated")
+        expires_date = parser.parser_output.get("expires")
+        self.assertEqual(created_date.year, 2002)
+        self.assertEqual(updated_date.year, 2020)
+        self.assertEqual(expires_date.year, 2021)
+        self.assertEqual(created_date.month, 4)
+        self.assertEqual(updated_date.month, 3)
+        self.assertEqual(expires_date.month, 4)
+        self.assertEqual(created_date.day, 19)
+        self.assertEqual(updated_date.day, 22)
+        self.assertEqual(expires_date.day, 18)
+        # geo
+        self.assertEqual(parser.parser_output.get("registrant_state"), "CA")
+        self.assertEqual(parser.parser_output.get("registrant_city"), "Mountain View")
+        self.assertEqual(parser.parser_output.get("registrant_country"), "US")
+        self.assertEqual(parser.parser_output.get("registrant_zipcode"), "94043")
+        self.assertEqual(parser.parser_output.get("registrant_address"), "1600 Amphitheatre Parkway")
+        # registrar
+        self.assertEqual(parser.parser_output.get("registrar"), "MarkMonitor, Inc.")
+        # registrant
+        self.assertEqual(parser.parser_output.get("registrant_organization"), "Google LLC")
+        self.assertEqual(parser.parser_output.get("registrant_name"), "Google Inc")
+        # misc
+        self.assertEqual(parser.parser_output.get("dnssec"), "unsigned")
+        self.assertEqual(len(parser.parser_output.get("name_servers")), 4)
+        self.assertEqual(len(parser.parser_output.get("status")), 3)
+
+    def test_parse_ar(self):
+        query_output = self.get_txt('ar')
+        parser = WhoIsParser('ar')
+        parser.parse(query_output)
+        # confirm dates
+        created_date = parser.parser_output.get("created")
+        updated_date = parser.parser_output.get("updated")
+        expires_date = parser.parser_output.get("expires")
+        self.assertEqual(created_date.year, 2013)
+        self.assertEqual(updated_date.year, 2019)
+        self.assertEqual(expires_date.year, 2020)
+        self.assertEqual(created_date.month, 10)
+        self.assertEqual(updated_date.month, 11)
+        self.assertEqual(expires_date.month, 11)
+        self.assertEqual(created_date.day, 29)
+        self.assertEqual(updated_date.day, 1)
+        self.assertEqual(expires_date.day, 1)
+        # registrar
+        self.assertEqual(parser.parser_output.get("registrar"), "nicar")
+        # registrant
+        self.assertEqual(parser.parser_output.get("registrant_name"), "GOOGLE INC.")
+        # misc
+        self.assertEqual(len(parser.parser_output.get("name_servers")), 2)
+        self.assertEqual(len(parser.parser_output.get("status")), 0)
+
+    def test_parse_no(self):
+        query_output = self.get_txt('no')
+        parser = WhoIsParser('no')
+        parser.parse(query_output)
+        # confirm dates
+        created_date = parser.parser_output.get("created")
+        updated_date = parser.parser_output.get("updated")
+        expires_date = parser.parser_output.get("expires")
+        self.assertIsNone(expires_date)
+        self.assertEqual(created_date.year, 2001)
+        self.assertEqual(updated_date.year, 2020)
+        self.assertEqual(created_date.month, 2)
+        self.assertEqual(updated_date.month, 1)
+        self.assertEqual(created_date.day, 26)
+        self.assertEqual(updated_date.day, 27)
+        # registrar
+        self.assertEqual(parser.parser_output.get("registrar"), "REG466-NORID")
+        # misc
+        self.assertEqual(len(parser.parser_output.get("name_servers")), 4)
+
+    def test_parser_ai(self):
+        query_output = self.get_txt('ai')
+        parser = WhoIsParser('ai')
+        parser.parse(query_output)
+        # confirm dates
+        created_date = parser.parser_output.get("created")
+        updated_date = parser.parser_output.get("updated")
+        expires_date = parser.parser_output.get("expires")
+        self.assertEqual(created_date.year, 2017)
+        self.assertEqual(updated_date.year, 2019)
+        self.assertEqual(expires_date.year, 2021)
+        self.assertEqual(created_date.month, 12)
+        self.assertEqual(updated_date.month, 8)
+        self.assertEqual(expires_date.month, 9)
+        self.assertEqual(created_date.day, 16)
+        self.assertEqual(updated_date.day, 24)
+        self.assertEqual(expires_date.day, 25)
+        # geo
+        self.assertEqual(parser.parser_output.get("registrant_state"), "CA")
+        self.assertEqual(parser.parser_output.get("registrant_country"), "US")
+        self.assertEqual(parser.parser_output.get("registrant_city"), "Mountain View")
+        self.assertEqual(parser.parser_output.get("registrant_zipcode"), "94043")
+        self.assertEqual(parser.parser_output.get("registrant_address"), "1600 Amphitheatre Parkway")
+        # registrar
+        self.assertEqual(parser.parser_output.get("registrar"), "Markmonitor")
+        # registrant
+        self.assertEqual(parser.parser_output.get("registrant_organization"), "Google LLC")
+        self.assertEqual(parser.parser_output.get("registrant_name"), "Domain Administrator")
+        # misc
+        self.assertEqual(parser.parser_output.get("dnssec"), "unsigned")
+        self.assertEqual(len(parser.parser_output.get("name_servers")), 4)
+        self.assertEqual(len(parser.parser_output.get("status")), 3)
+
+    def test_parser_me(self):
+        query_output = self.get_txt('me')
+        parser = WhoIsParser('me')
+        parser.parse(query_output)
+        # confirm dates
+        created_date = parser.parser_output.get("created")
+        updated_date = parser.parser_output.get("updated")
+        expires_date = parser.parser_output.get("expires")
+        self.assertEqual(created_date.year, 2008)
+        self.assertEqual(updated_date.year, 2020)
+        self.assertEqual(expires_date.year, 2021)
+        self.assertEqual(created_date.month, 6)
+        self.assertEqual(updated_date.month, 5)
+        self.assertEqual(expires_date.month, 6)
+        self.assertEqual(created_date.day, 13)
+        self.assertEqual(updated_date.day, 12)
+        self.assertEqual(expires_date.day, 13)
+        # geo
+        self.assertEqual(parser.parser_output.get("registrant_state"), "CA")
+        self.assertEqual(parser.parser_output.get("registrant_country"), "US")
+        # registrar
+        self.assertEqual(parser.parser_output.get("registrar"), "MarkMonitor Inc.")
+        # registrant
+        self.assertEqual(parser.parser_output.get("registrant_organization"), "Google LLC")
+        # misc
+        self.assertEqual(parser.parser_output.get("dnssec"), "unsigned")
+        self.assertEqual(len(parser.parser_output.get("name_servers")), 4)
+        self.assertEqual(len(parser.parser_output.get("status")), 6)


### PR DESCRIPTION
Included tests for ai, ar, de, me, no, and us top level domains.
Some tweaks to a few of these parsers were also included.