### PR TITLE
Add LICENSE file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include asyncwhois/data/*
+include LICENSE


### PR DESCRIPTION
This ensures that the LICENSE file is part of the source tarball which is available at PyPI.