### PR TITLE
Use enums for parser

### DIFF
--- a/tests/samples/tld_online.txt
+++ b/tests/samples/tld_online.txt
@@ -1,0 +1,45 @@
+Domain Name: GOOGLE.ONLINE
+Registry Domain ID: D9566483-CNIC
+Registrar WHOIS Server: whois.markmonitor.com
+Registrar URL:
+Updated Date: 2020-08-25T02:39:31.0Z
+Creation Date: 2015-08-19T11:27:00.0Z
+Registry Expiry Date: 2021-08-19T23:59:59.0Z
+Registrar: MarkMonitor, Inc (TLDs)
+Registrar IANA ID: 292
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+Registrant Organization: Google LLC
+Registrant State/Province: CA
+Registrant Country: US
+Registrant Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Admin Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Tech Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Name Server: NS3.GOOGLEDOMAINS.COM
+Name Server: NS1.GOOGLEDOMAINS.COM
+Name Server: NS2.GOOGLEDOMAINS.COM
+Name Server: NS4.GOOGLEDOMAINS.COM
+DNSSEC: unsigned
+Registrar Abuse Contact Email: ccops@markmonitor.com
+Registrar Abuse Contact Phone: +1.2083895740
+URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2021-01-06T19:39:26.0Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+>>> IMPORTANT INFORMATION ABOUT THE DEPLOYMENT OF RDAP: please visit
+https://www.centralnic.com/support/rdap <<<
+
+The Whois and RDAP services are provided by CentralNic, and contain
+information pertaining to Internet domain names registered by our
+our customers. By using this service you are agreeing (1) not to use any
+information presented here for any purpose other than determining
+ownership of domain names, (2) not to store or reproduce this data in
+any way, (3) not to use any high-volume, automated, electronic processes
+to obtain data from this service. Abuse of this service is monitored and
+actions in contravention of these terms will result in being permanently
+blacklisted. All data is (c) CentralNic Ltd (https://www.centralnic.com)
+
+Access to the Whois and RDAP services is rate limited. For more
+information, visit https://registrar-console.centralnic.com/pub/whois_guidance.

--- a/tests/test_parser_output.py
+++ b/tests/test_parser_output.py
@@ -147,15 +147,15 @@ class TestWhoIsParsers(unittest.TestCase):
         self.assertEqual(updated_date.day, 7)
         self.assertEqual(expires_date.day, 22)
         # geo
-        self.assertEqual(parser.parser_output.get("registrant_state"), None)
-        self.assertEqual(parser.parser_output.get("registrant_country"), None)
+        self.assertEqual(parser.parser_output.get("registrant_state"), "CA")
+        self.assertEqual(parser.parser_output.get("registrant_country"), "US")
         self.assertEqual(parser.parser_output.get("registrant_zipcode"), None)
-        self.assertEqual(parser.parser_output.get("registrant_address"), "1600 Amphitheatre Parkway, Mountain View, CA, US")
+        self.assertEqual(parser.parser_output.get("registrant_address"), "1600 Amphitheatre Parkway")
         # registrar
         self.assertEqual(parser.parser_output.get("registrar"), None)
         # registrant
         self.assertEqual(parser.parser_output.get("registrant_organization"), "Google Inc.")
-        self.assertEqual(parser.parser_output.get("registrant_name"), "(Domain Holder) Google Inc.")
+        self.assertEqual(parser.parser_output.get("registrant_name"), "Google Inc.")
 
     def test_parser_icu(self):
         query_output = self.get_txt('icu')
@@ -746,4 +746,31 @@ class TestWhoIsParsers(unittest.TestCase):
         self.assertEqual(parser.parser_output.get("registrar"), "Markmonitor, Inc.")
         # misc
         self.assertEqual(parser.parser_output.get("dnssec"), "Unsigned")
+        self.assertEqual(len(parser.parser_output.get("name_servers")), 4)
+
+    def test_parser_online(self):
+        query_output = self.get_txt('online')
+        parser = WhoIsParser('online')
+        parser.parse(query_output)
+        # confirm dates
+        created_date = parser.parser_output.get("created")
+        updated_date = parser.parser_output.get("updated")
+        expires_date = parser.parser_output.get("expires")
+        self.assertEqual(created_date.year, 2015)
+        self.assertEqual(updated_date.year, 2020)
+        self.assertEqual(expires_date.year, 2021)
+        self.assertEqual(created_date.month, 8)
+        self.assertEqual(updated_date.month, 8)
+        self.assertEqual(expires_date.month, 8)
+        self.assertEqual(created_date.day, 19)
+        self.assertEqual(updated_date.day, 25)
+        self.assertEqual(expires_date.day, 19)
+        # registrar
+        self.assertEqual(parser.parser_output.get("registrar"), "MarkMonitor, Inc (TLDs)")
+        # registrant
+        self.assertEqual(parser.parser_output.get("registrant_organization"), "Google LLC")
+        self.assertEqual(parser.parser_output.get("registrant_country"), "US")
+        self.assertEqual(parser.parser_output.get("registrant_state"), "CA")
+        # misc
+        self.assertEqual(parser.parser_output.get("dnssec"), "unsigned")
         self.assertEqual(len(parser.parser_output.get("name_servers")), 4)


### PR DESCRIPTION
This PR implements a new class called "BaseKeys". It contains
a standardized list of keys to be used across parsers. The keys within each 
parser were updated to match these. This change should help prevent
"typos" or irregularities between future parser classes.