### PR TITLE
Create parsers for ge, gg, aw, ax TLDs

### DIFF
--- a/asyncwhois/parser.py
+++ b/asyncwhois/parser.py
@@ -577,15 +577,13 @@ class RegexEU(BaseParser):
 
 
 class RegexDE(BaseParser):
-    """
-    .de disclaimer (very hard to extract information from this provider):
-
-    % The DENIC whois service on port 43 doesn't disclose any information concerning
-    % the domain holder, general request and abuse contact.
-    % This information can be obtained through use of our web-based whois service
-    % available at the DENIC website:
-    % http://www.denic.de/en/domains/whois-service/web-whois.html
-    """
+    # .de disclaimer (very hard to extract information from this provider):
+    #
+    # % The DENIC whois service on port 43 doesn't disclose any information concerning
+    # % the domain holder, general request and abuse contact.
+    # % This information can be obtained through use of our web-based whois service
+    # % available at the DENIC website:
+    # % http://www.denic.de/en/domains/whois-service/web-whois.html
 
     _de_expressions = {
         BaseKeys.UPDATED: r'Changed: *(.+)',
@@ -628,10 +626,10 @@ class RegexJP(BaseParser):
     _jp_expressions = {
         BaseKeys.REGISTRANT_NAME: r'\[Registrant\] *(.+)',
         BaseKeys.CREATED: r'\[登録年月日\] *(.+)',
-        BaseKeys.EXPIRES: r'\[有効期限\] *(.+)',
+        BaseKeys.EXPIRES: r'\[(?:有効限|有効期限)\]*(.+)',
         BaseKeys.STATUS: r'\[状態\] *(.+)',
         BaseKeys.UPDATED: r'\[最終更新\] *(.+)',
-        BaseKeys.NAME_SERVERS: r'\[Name Server\]:: *(.+)'
+        BaseKeys.NAME_SERVERS: r'\[Name Server\] *(.+)'
     }
 
     def __init__(self):
@@ -641,7 +639,7 @@ class RegexJP(BaseParser):
 
     def parse(self, blob: str) -> Dict[str, Any]:
         parsed_output = super().parse(blob)
-        address_match = re.search(r"[Postal Address] *(.+)[電話番号]", blob, re.DOTALL)
+        address_match = re.search(r"\[Postal Address\]([^\[|.]+)\[\w+\](.+)", blob, re.DOTALL)
         if address_match:
             address_pieces = [m.strip() for m in address_match.group(1).split('\n') if m.strip()]
             parsed_output[BaseKeys.REGISTRANT_ADDRESS] = ", ".join(address_pieces)
@@ -1103,13 +1101,13 @@ class RegexCZ(BaseParser):
 
 class RegexHR(BaseParser):
     _hr_expressions = {
-        BaseKeys.DOMAIN_NAME: 'Domain Name: *(.+)',
-        BaseKeys.UPDATED: 'Updated Date: *(.+)',
-        BaseKeys.CREATED: 'Creation Date: *(.+)',
-        BaseKeys.EXPIRES: 'Registrar Registration Expiration Date: *(.+)',
-        BaseKeys.NAME_SERVERS: 'Name Server: *(.+)',
-        BaseKeys.REGISTRANT_NAME: 'Registrant Name:\s(.+)',
-        BaseKeys.REGISTRANT_ADDRESS: 'Registrant Street:\s*(.+)',
+        BaseKeys.DOMAIN_NAME: r'Domain Name: *(.+)',
+        BaseKeys.UPDATED: r'Updated Date: *(.+)',
+        BaseKeys.CREATED: r'Creation Date: *(.+)',
+        BaseKeys.EXPIRES: r'Registrar Registration Expiration Date: *(.+)',
+        BaseKeys.NAME_SERVERS: r'Name Server: *(.+)',
+        BaseKeys.REGISTRANT_NAME: r'Registrant Name:\s(.+)',
+        BaseKeys.REGISTRANT_ADDRESS: r'Registrant Street:\s*(.+)',
     }
 
     def __init__(self):

--- a/asyncwhois/parser.py
+++ b/asyncwhois/parser.py
@@ -179,6 +179,37 @@ class BaseParser:
                 return self._process(match.group(1))
             return None
 
+    def find_multiline_match(self, start: str, blob: str) -> List[str]:
+        """
+        Used to find multiple lines related to a single key within the
+        WHOIS query response. Assumes the values are on a newline below
+        the key, and that a blank line separates the last value from the
+        next key or end of the text.
+
+        Example:
+        -------
+        example_blob = '''
+            Name servers:
+                 ns1.google.com
+                 ns2.google.com
+                 ns3.google.com
+                 ns4.google.com
+
+        '''
+        find_multiline_match('Name servers:\n', example_blob)
+        # would return... ['ns1.google.com', 'ns2.google.com', 'ns3.google.com', 'ns4.google.com']
+
+        :param start: a key that identifies where to begin the multiline search in blob
+        :param blob: the whois query text
+        :return: a list of values as strings
+        """
+        matches = []
+        regex_string = start + r'\s+([A-Za-z0-9\.\s]+\n\n)'
+        multiline_match = re.search(regex_string, blob, re.DOTALL | re.IGNORECASE)
+        if multiline_match:
+            matches = self._process_many(multiline_match.group(1))
+        return matches
+
     @staticmethod
     def _parse_date(date_string: str) -> Union[datetime.datetime, str]:
         """
@@ -198,9 +229,11 @@ class BaseParser:
     def _process_many(self, match: str) -> List[str]:
         if '\n' in match:
             match = match.split('\n')
-            return [self._process(m) for m in match if m]
+            matches = [self._process(m) for m in match if m]
+            return [m for m in matches if m]  # remove empty strings
         else:
-            return [self._process(match)]
+            match = self._process(match)
+            return [match] if match else []  # remove empty strings
 
     @staticmethod
     def _process(match: str) -> str:
@@ -405,7 +438,6 @@ class RegexCL(BaseParser):
 class RegexPL(BaseParser):
     _pl_expressions = {
         BaseKeys.DOMAIN_NAME: r'DOMAIN NAME: *(.+)\n',
-        BaseKeys.NAME_SERVERS: r'nameservers:(.*?)created',
         BaseKeys.REGISTRAR: r'REGISTRAR:\s*(.+)',
         BaseKeys.CREATED: r'created: *(.+)',
         BaseKeys.EXPIRES: r'option expiration date: *(.+)',
@@ -418,17 +450,10 @@ class RegexPL(BaseParser):
         self.update_reg_expressions(self._pl_expressions)
 
     def parse(self, blob: str) -> Dict[str, Any]:
-        parsed_output = {}
-        for key, regex in self.reg_expressions.items():
-            if key == BaseKeys.NAME_SERVERS:
-                match = self.find_match(regex, blob, flags=re.DOTALL | re.IGNORECASE, many=False)
-                parsed_output[BaseKeys.NAME_SERVERS] = [self._process(m) for m in match.split('\n')]
-            else:
-                many = key in self.multiple_match_keys
-                parsed_output[key] = self.find_match(regex, blob, many=many)
-                if key in self.date_keys and parsed_output.get(key, None):
-                    parsed_output[key] = self._parse_date(parsed_output.get(key))
-
+        parsed_output = super().parse(blob)
+        nameservers_match = self.find_match(r'nameservers:*(.+)\ncreated:\s', blob, flags=re.DOTALL | re.IGNORECASE)
+        if nameservers_match:
+            parsed_output[BaseKeys.NAME_SERVERS] = [self._process(m) for m in nameservers_match.split('\n')]
         return parsed_output
 
 
@@ -538,10 +563,8 @@ class RegexEU(BaseParser):
 
     def parse(self, blob: str) -> Dict[str, Any]:
         parsed_output = super().parse(blob)
-        name_servers_match = re.search(r"Name servers:\n(.+)", blob, re.DOTALL | re.IGNORECASE)
-        if name_servers_match:
-            name_servers = name_servers_match.group(1).split('\n')
-            parsed_output[BaseKeys.NAME_SERVERS] = [self._process(ns) for ns in name_servers if ns]
+        # find name servers
+        parsed_output[BaseKeys.NAME_SERVERS] = self.find_multiline_match("Name servers:", blob)
         return parsed_output
 
 
@@ -589,9 +612,7 @@ class RegexUK(BaseParser):
             address_pieces = [m.strip() for m in address_match.group(1).split('\n') if m.strip()]
             parsed_output[BaseKeys.REGISTRANT_ADDRESS] = ", ".join(address_pieces)
         # find name servers
-        ns_match = re.search(r"Name servers: *(.+)WHOIS lookup", blob, re.DOTALL)
-        if ns_match:
-            parsed_output[BaseKeys.NAME_SERVERS] = [m.strip() for m in ns_match.group(1).split('\n') if m.strip()]
+        parsed_output[BaseKeys.NAME_SERVERS] = self.find_multiline_match("Name servers:", blob)
         return parsed_output
 
 
@@ -633,6 +654,7 @@ class RegexAU(BaseParser):
 
 class RegexAT(BaseParser):
     _at_expressions = {
+        BaseKeys.DOMAIN_NAME: r'domain: *(.+)',
         BaseKeys.REGISTRAR: r'registrar: *(.+)',
         BaseKeys.REGISTRANT_NAME: r'personname: *(.+)',
         BaseKeys.REGISTRANT_ADDRESS: r'street address: *(.+)',
@@ -640,19 +662,12 @@ class RegexAT(BaseParser):
         BaseKeys.REGISTRANT_CITY: r'city: *(.+)',
         BaseKeys.REGISTRANT_COUNTRY: r'country: *(.+)',
         BaseKeys.UPDATED: r'changed: *(.+)',
+        BaseKeys.NAME_SERVERS: r'nserver :*(.+)'
     }
 
     def __init__(self):
         super().__init__()
         self.update_reg_expressions(self._at_expressions)
-
-    def parse(self, blob: str) -> Dict[str, Any]:
-        parsed_output = {BaseKeys.NAME_SERVERS: self.find_match(r'nserver :*(.+)', blob, many=True)}
-        for key, pattern in self.reg_expressions.items():
-            match = re.search(pattern, blob)
-            if match:
-                parsed_output[key] = self._process(match.group(1))
-        return parsed_output
 
 
 class RegexBE(BaseParser):
@@ -669,9 +684,7 @@ class RegexBE(BaseParser):
 
     def parse(self, blob: str) -> Dict[str, Any]:
         parsed_output = super().parse(blob)
-        ns_match = re.search(r"Name servers: *(.+)Keys: ", blob, re.DOTALL)
-        if ns_match:
-            parsed_output[BaseKeys.NAME_SERVERS] = [m.strip() for m in ns_match.group(1).split('\n') if m.strip()]
+        parsed_output[BaseKeys.NAME_SERVERS] = self.find_multiline_match("Name servers:", blob)
         return parsed_output
 
 
@@ -706,9 +719,7 @@ class RegexKG(BaseParser):
 
     def parse(self, blob: str) -> Dict[str, Any]:
         parsed_output = super().parse(blob)
-        ns_match = re.search(r"Name servers in the listed order: *(.+)", blob, re.DOTALL)
-        if ns_match:
-            parsed_output[BaseKeys.NAME_SERVERS] = [m.strip() for m in ns_match.group(1).split('\n') if m.strip()]
+        parsed_output[BaseKeys.NAME_SERVERS] = self.find_multiline_match("Name servers in the listed order:", blob)
         return parsed_output
 
 
@@ -1332,13 +1343,8 @@ class RegexTK(BaseParser):
 
     def parse(self, blob: str) -> Dict[str, Any]:
         parsed_output = super().parse(blob)
-        # name servers
-        name_server_match = re.search(r'Domain Nameservers:(?:.*?)*(.+)Domain registered', blob,
-                                      re.IGNORECASE | re.DOTALL)
-        if name_server_match:
-            name_servers = [self._process(m) for m in name_server_match.group(1).split('\n')]
-            parsed_output[BaseKeys.NAME_SERVERS] = [ns for ns in name_servers if ns]
-
+        # handle multiline nameservers
+        parsed_output[BaseKeys.NAME_SERVERS] = self.find_multiline_match('Domain nameservers:', blob)
         # a date parser exists for '%d/%m/%Y', but this interferes with the parser needed
         # for this one, which is '%m/%d/%Y', so this date format needs to be parsed separately here
         created_match = re.search(r'Domain registered: *(.+)', blob, re.IGNORECASE)
@@ -1347,7 +1353,6 @@ class RegexTK(BaseParser):
         expires_match = re.search(r'Record will expire on: *(.+)', blob, re.IGNORECASE)
         if expires_match:
             parsed_output[BaseKeys.EXPIRES] = datetime.datetime.strptime(expires_match.group(1), '%m/%d/%Y')
-
         # split domain and status
         domain_name_match = re.search(f'Domain name:(?:.*?)*(.+)Owner contact:', blob, re.IGNORECASE | re.DOTALL)
         if domain_name_match:
@@ -1357,7 +1362,6 @@ class RegexTK(BaseParser):
                 parsed_output[BaseKeys.STATUS] = [self._process(domain_and_status[1])]
             else:
                 parsed_output[BaseKeys.DOMAIN_NAME] = domain_and_status
-
         return parsed_output
 
 
@@ -1409,11 +1413,8 @@ class RegexEDU(BaseParser):
             parsed_output[BaseKeys.REGISTRANT_COUNTRY] = country
             parsed_output[BaseKeys.REGISTRANT_ADDRESS] = address
 
-        name_servers_match = re.search(r'Name Servers:(.*?)Domain', blob, re.IGNORECASE | re.DOTALL)
-        if name_servers_match:
-            name_servers = [self._process(m) for m in name_servers_match.group(1).split('\n')]
-            parsed_output[BaseKeys.NAME_SERVERS] = [ns for ns in name_servers if ns]
-
+        # handle multiline nameservers
+        parsed_output[BaseKeys.NAME_SERVERS] = self.find_multiline_match('Name Servers:', blob)
         return parsed_output
 
 
@@ -1453,10 +1454,8 @@ class RegexNL(BaseParser):
 
     def parse(self, blob: str) -> Dict[str, Any]:
         parsed_output = super().parse(blob)
-        name_servers_match = re.search(r'Domain nameservers:\n(.+)Record maintained', blob, re.DOTALL | re.IGNORECASE)
-        if name_servers_match:
-            name_servers = [self._process(m) for m in name_servers_match.group(1).split('\n')]
-            parsed_output[BaseKeys.NAME_SERVERS] = [ns for ns in name_servers if ns]
+        # handle multiline nameservers
+        parsed_output[BaseKeys.NAME_SERVERS] = self.find_multiline_match('Domain nameservers:', blob)
         return parsed_output
 
 

--- a/tests/samples/tld_aw.txt
+++ b/tests/samples/tld_aw.txt
@@ -1,0 +1,38 @@
+Domain name: google.aw
+Status:      active
+
+Registrar:
+   SETAR N.V.
+   Administration Building
+   Seroe Blanco 29A
+   Oranjestad
+   Aruba
+
+Abuse Contact:
+
+Creation Date: 2017-09-13
+
+Updated Date: 2018-05-21
+
+DNSSEC:      no
+
+Domain nameservers:
+   ns1.googledomains.com
+   ns2.googledomains.com
+   ns3.googledomains.com
+   ns4.googledomains.com
+
+Record maintained by: AW Domain Registry
+
+Copyright notice
+No part of this publication may be reproduced, published, stored in a
+retrieval system, or transmitted, in any form or by any means,
+electronic, mechanical, recording, or otherwise, without prior
+permission of Setar.
+
+Any use of this material for advertising, targeting commercial offers or
+similar activities is explicitly forbidden and liable to result in legal
+action. Anyone who is aware or suspects that such activities are taking
+place is asked to inform Setar in Aruba.
+(c) Setar Aruban Copyright Act, protection of authors' rights (Section 10,
+subsection 1, clause 1).

--- a/tests/samples/tld_ax.txt
+++ b/tests/samples/tld_ax.txt
@@ -1,0 +1,30 @@
+domain...............: google.ax
+status...............: Registered
+created..............: 08.09.2016
+expires..............: 08.09.2021
+available............: 08.10.2021
+modified.............: 05.09.2020
+RegistryLock.........: no
+
+Nameservers
+
+nserver..............: kate.ns.cloudflare.com
+nserver..............: merlin.ns.cloudflare.com
+
+Holder
+
+name.................: xTom GmbH
+address..............: Kreuzstr.60
+address..............: 40210
+address..............: Duesseldorf
+country..............: Tyskland
+phone................: +49 21197635976
+holder email.........: domains@xtom.com
+
+Registrar
+
+registrar............: xTom
+www..................: https://xtom.com/
+
+Copyright (c) Ã
+lands Landskapsregering

--- a/tests/samples/tld_ge.txt
+++ b/tests/samples/tld_ge.txt
@@ -1,0 +1,40 @@
+   Domain Name: GOOGLE.GE
+   Creation Date: 2006-07-28
+   Registry Expiry Date: 2021-07-29
+   Registrar: proservice ltd
+   Domain Status: Ok
+   Registrant: Google LLC
+   Admin Name: Google LLC
+   Admin Email: dns-admin@google.com
+   Tech Name: Google LLC
+   Tech Email: dns-admin@google.com
+   Name Server: ns4.google.com
+   Name Server: ns3.google.com
+   Name Server: ns2.google.com
+   Name Server: ns1.google.com
+
+
+TERMS OF USE:
+The WHOIS service is provided solely for informational purposes.
+You are not authorized to access or query our Whois
+database through the use of electronic processes that are high-volume and
+automated except as reasonably necessary to register domain names or
+modify existing registrations; the Data is provided by NIC for
+information purposes only, and to assist persons in obtaining information
+about or related to a domain name registration record. NIC does not
+guarantee its accuracy. By submitting a Whois query, you agree to abide
+by the following terms of use: You agree that you may use this Data only
+for lawful purposes and that under no circumstances will you use this Data
+to: (1) allow, enable, or otherwise support the transmission of mass
+unsolicited, commercial advertising or solicitations via e-mail, telephone,
+or facsimile; or (2) enable high volume, automated, electronic processes
+that apply to NIC (or its computer systems). The compilation,
+repackaging, dissemination or other use of this Data is expressly
+prohibited without the prior written consent of NIC. You agree not to
+use electronic processes that are automated and high-volume to access or
+query the Whois database except as reasonably necessary to register
+domain names or modify existing registrations. NIC reserves the right
+to restrict your access to the Whois database in its sole discretion to ensure
+operational stability.  NIC may restrict or terminate your access to the
+Whois database for failure to abide by these terms of use. NIC
+reserves the right to modify these terms at any time.

--- a/tests/samples/tld_gg.txt
+++ b/tests/samples/tld_gg.txt
@@ -1,0 +1,50 @@
+Domain:
+     google.gg
+
+Domain Status:
+     Active
+     Delete Prohibited by Registrar
+     Update Prohibited by Registrar
+     Transfer Prohibited by Registrar
+
+Registrant:
+     Google LLC
+
+Registrar:
+     MarkMonitor Inc. (http://www.markmonitor.com)
+
+Relevant dates:
+     Registered on 30th April 2003 at 00:04:00.000
+     Registry fee due on 30th April each year
+
+Registration status:
+     Registered until cancelled
+
+Name servers:
+     ns1.google.com
+     ns2.google.com
+     ns3.google.com
+     ns4.google.com
+
+
+WHOIS lookup made on Mon, 15 Mar 2021 at 19:28:23 GMT
+
+This WHOIS information is provided for free by CIDR, operator of
+the backend registry for domain names ending in GG, JE, and AS.
+
+Copyright (c) and database right Island Networks 1996 - 2021.
+
+You may not access this WHOIS server or use any data from it except
+as permitted by our Terms and Conditions which are published
+at http://www.channelisles.net/legal/whoisterms
+
+They include restrictions and prohibitions on
+
+- using or re-using the data for advertising;
+- using or re-using the service for commercial purposes without a licence;
+- repackaging, recompilation, redistribution or reuse;
+- obscuring, removing or hiding any or all of this notice;
+- exceeding query rate or volume limits.
+
+The data is provided on an 'as-is' basis and may lag behind the
+register. Access may be withdrawn or restricted at any time.

--- a/tests/samples/tld_jp.txt
+++ b/tests/samples/tld_jp.txt
@@ -1,0 +1,44 @@
+[ JPRS database provides information on network administration. Its use
+ is    ]
+[ restricted to network administration purposes. For further
+information,     ]
+"[ use whois -h whois.jprs.jp help. To suppress Japanese output, "
+"add/e     ]"
+"[ at the end of command, e.g. whois -h whois.jprs.jp "
+"xxx/e.                 ]"
+
+Domain Information: [ドメイン情報]
+[Domain Name]                   AMAZON.JP
+
+[登録者名]                      Amazon, Inc.
+[Registrant]                    Amazon, Inc.
+
+[Name Server]                   pdns1.ultradns.net
+[Name Server]                   pdns6.ultradns.co.uk
+[Name Server]                   pdns2.ultradns.net
+[Name Server]                   pdns5.ultradns.info
+[Name Server]                   pdns3.ultradns.org
+[Name Server]                   pdns4.ultradns.org
+[Name Server]                   ns2.p31.dynect.net
+[Name Server]                   ns1.p31.dynect.net
+[Signing Key]
+
+[登録年月日]                    2010/09/22
+[有効限]                      2021/09/30
+[状態]                          Active
+[最終更新]                      2020/10/01 01:05:09 (JST)
+
+Contact Information: [公開連絡窓口]
+[名前]                          Amazon, Inc.
+[Name]                          Amazon, Inc.
+[Email]                         hostmaster@amazon.com
+[Web Page]
+[郵便番号]                      150-0002
+[住]                          東京都Meguro-ku
+                             Arco Tower Annex
+                             8-1, Shimomeguro 1-chome
+[Postal Address]                Meguro-ku
+                             Arco Tower Annex
+                             8-1, Shimomeguro 1-chome
+[電話番号]                      +81.342884000
+[FAX番号]

--- a/tests/test_parser_methods.py
+++ b/tests/test_parser_methods.py
@@ -23,3 +23,32 @@ class TestWhoIsParserMethods(unittest.TestCase):
         for date_string in date_strings:
             formatted_date = BaseParser._parse_date(date_string)
             self.assertIsInstance(formatted_date, datetime.datetime)
+
+    def test_find_match(self):
+        test_blob = """
+        Domain name: google.com
+        Name server: ns1.google.com
+        Name server: ns2.google.com
+        Status: ok
+        """
+        domain = BaseParser().find_match(r'domain name: *(.+)', test_blob)
+        self.assertEqual(domain, "google.com")
+        name_servers = BaseParser().find_match(r'name server: *(.+)', test_blob, many=True)
+        self.assertEqual(len(name_servers), 2)
+        status = BaseParser().find_match(r'status: *(.+)', test_blob, many=True)
+        self.assertEqual(len(status), 1)
+
+    def test_find_multiline_match(self):
+        test_blob = """
+        Domain name: google.com
+        
+        Domain nameservers:
+           ns1.googledomains.com
+           ns2.googledomains.com
+           ns3.googledomains.com
+           ns4.googledomains.com
+
+        Registrar: someone
+        """
+        name_servers = BaseParser().find_multiline_match(r'Domain nameservers:\n', test_blob)
+        self.assertEqual(len(name_servers), 4)

--- a/tests/test_parser_output.py
+++ b/tests/test_parser_output.py
@@ -1050,3 +1050,112 @@ class TestWhoIsParsers(unittest.TestCase):
         self.assertEqual(parser.parser_output.get("registrant_organization"), "Amazon Europe Holding Technologies SCS")
         self.assertEqual(parser.parser_output.get("registrant_address"), "65, boulevard Grande-Duchesse Charlotte, Luxembourg City, 1331, LU")
         self.assertEqual(len(parser.parser_output.get("name_servers")), 6)
+
+    def test_tld_gg(self):
+        query_output = self.get_txt('gg')
+        parser = WhoIsParser('gg')
+        parser.parse(query_output)
+        # confirm dates
+        created_date = parser.parser_output.get("created")
+        self.assertEqual(created_date.year, 2003)
+        self.assertEqual(created_date.month, 4)
+        self.assertEqual(created_date.day, 30)
+        # registrant
+        self.assertEqual(parser.parser_output.get("registrant_name"), "Google LLC")
+        # registrar
+        self.assertEqual(parser.parser_output.get("registrar"), "MarkMonitor Inc. (http://www.markmonitor.com)")
+        # name servers and status
+        self.assertEqual(len(parser.parser_output.get("name_servers")), 4)
+        self.assertEqual(len(parser.parser_output.get("status")), 4)
+
+    def test_tld_ge(self):
+        query_output = self.get_txt('ge')
+        parser = WhoIsParser('ge')
+        parser.parse(query_output)
+        # confirm dates
+        created_date = parser.parser_output.get("created")
+        self.assertEqual(created_date.year, 2006)
+        self.assertEqual(created_date.month, 7)
+        self.assertEqual(created_date.day, 28)
+        expired_date = parser.parser_output.get("expires")
+        self.assertEqual(expired_date.year, 2021)
+        self.assertEqual(expired_date.month, 7)
+        self.assertEqual(expired_date.day, 29)
+        # registrant
+        self.assertEqual(parser.parser_output.get("registrant_name"), "Google LLC")
+        # registrar
+        self.assertEqual(parser.parser_output.get("registrar"), "proservice ltd")
+        # misc
+        self.assertEqual(len(parser.parser_output.get("name_servers")), 4)
+        self.assertEqual(len(parser.parser_output.get("status")), 1)
+
+    def test_tld_jp(self):
+        query_output = self.get_txt('jp')
+        parser = WhoIsParser('jp')
+        parser.parse(query_output)
+        # confirm dates
+        created_date = parser.parser_output.get("created")
+        self.assertEqual(created_date.year, 2010)
+        self.assertEqual(created_date.month, 9)
+        self.assertEqual(created_date.day, 22)
+        #
+        expires_date = parser.parser_output.get("expires")
+        self.assertEqual(expires_date.year, 2021)
+        self.assertEqual(expires_date.month, 9)
+        self.assertEqual(expires_date.day, 30)
+        # registrant
+        self.assertEqual(parser.parser_output.get("registrant_name"), "Amazon, Inc.")
+        # address
+        self.assertEqual(parser.parser_output.get("registrant_address"),
+                         "Meguro-ku, Arco Tower Annex, 8-1, Shimomeguro 1-chome")
+        # name servers
+        self.assertEqual(len(parser.parser_output.get("name_servers")), 8)
+
+    def test_tld_ax(self):
+        query_output = self.get_txt('ax')
+        parser = WhoIsParser('ax')
+        parser.parse(query_output)
+        # confirm dates
+        created_date = parser.parser_output.get("created")
+        self.assertEqual(created_date.year, 2016)
+        self.assertEqual(created_date.month, 9)
+        self.assertEqual(created_date.day, 8)
+        expired_date = parser.parser_output.get("expires")
+        self.assertEqual(expired_date.year, 2021)
+        self.assertEqual(expired_date.month, 9)
+        self.assertEqual(expired_date.day, 8)
+        updated_date = parser.parser_output.get("updated")
+        self.assertEqual(updated_date.year, 2020)
+        self.assertEqual(updated_date.month, 9)
+        self.assertEqual(updated_date.day, 5)
+        # registrant
+        self.assertEqual(parser.parser_output.get("registrant_name"), "xTom GmbH")
+        self.assertEqual(parser.parser_output.get("registrant_country"), "Tyskland")
+        self.assertEqual(parser.parser_output.get("registrant_address"), "Kreuzstr.60, 40210, Duesseldorf")
+        # registrar
+        self.assertEqual(parser.parser_output.get("registrar"), "xTom")
+        # misc
+        self.assertEqual(len(parser.parser_output.get("name_servers")), 2)
+        self.assertEqual(len(parser.parser_output.get("status")), 1)
+        self.assertEqual(parser.parser_output.get("domain_name"), "google.ax")
+
+    def test_tld_aw(self):
+        query_output = self.get_txt('aw')
+        parser = WhoIsParser('aw')
+        parser.parse(query_output)
+        # confirm dates
+        created_date = parser.parser_output.get("created")
+        self.assertEqual(created_date.year, 2017)
+        self.assertEqual(created_date.month, 9)
+        self.assertEqual(created_date.day, 13)
+        updated_date = parser.parser_output.get("updated")
+        self.assertEqual(updated_date.year, 2018)
+        self.assertEqual(updated_date.month, 5)
+        self.assertEqual(updated_date.day, 21)
+        # registrar
+        self.assertEqual(parser.parser_output.get("registrar"), "SETAR N.V.")
+        # misc
+        self.assertEqual(parser.parser_output.get("dnssec"), "no")
+        self.assertEqual(len(parser.parser_output.get("name_servers")), 4)
+        self.assertEqual(len(parser.parser_output.get("status")), 1)
+        self.assertEqual(parser.parser_output.get("domain_name"), "google.aw")


### PR DESCRIPTION
This PR
- adds parsers for the ge, gg, aw, ax with tests
- fixes bug with how the jp parser handles address
- adds multiline value finder, which helps DRY name server parsing
- misc clean up; comments, white space, and doc strings