### PR TITLE
Fix tk parser bug

### DIFF
--- a/asyncwhois/parse_tld.py
+++ b/asyncwhois/parse_tld.py
@@ -84,7 +84,8 @@ class DomainParser:
         'domain name not known',
         'no object found',
         'available for re-registration',
-        'object does not exist'
+        'object does not exist',
+        'domain you requested is not known',
     ]
 
     def __init__(self, tld: str):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -12,25 +12,18 @@ class TestWhoIsQuery(unittest.TestCase):
         # test connect
         test_address_tuple_param = ('0.0.0.0', 69)
         test_timeout_param = 10
-        # call WhoIsQuery's "_create_connection" method
-        asyncwhois.query.WhoIsQuery._create_connection(test_address_tuple_param, test_timeout_param)
+        with asyncwhois.query.Query()._create_connection(test_address_tuple_param) as _:
+            ...
         mock_socket_lib.create_connection.assert_called()
-        mock_socket_lib.create_connection.assert_called_with(address=test_address_tuple_param,
-                                                             timeout=test_timeout_param)
+        mock_socket_lib.create_connection.assert_called_with(test_address_tuple_param,
+                                                             test_timeout_param)
 
     @mock.patch('asyncwhois.query.socket.socket')
     def test_whois_query_send_and_recv(self, mock_socket_instance):
         test_data_send_string = "a-domain-to-send"
         test_data_recv_bytes = b""  # empty so _send_and_recv does not infinite loop
         mock_socket_instance.recv.return_value = test_data_recv_bytes
-        asyncwhois.query.WhoIsQuery._send_and_recv(mock_socket_instance, test_data_send_string)
+        asyncwhois.query.Query._send_and_recv(mock_socket_instance, test_data_send_string)
         mock_socket_instance.recv.assert_called()
         mock_socket_instance.sendall.assert_called()
         mock_socket_instance.sendall.assert_called_with(test_data_send_string.encode())
-
-    @mock.patch('asyncwhois.query.WhoIsQuery._send_and_recv')
-    def test_whois_query_run(self, mock_send_recv):
-        mock_send_recv.return_value = ""
-        self.assertRaises(QueryError, asyncwhois.query.WhoIsQuery, "some-domain")
-
-


### PR DESCRIPTION
Fixes an issue where where the process would hang due to a bad regular expression within the .tk parser. 
The phrase "available for re-registration" was added to `DomainParser._no_match_checks`, which makes sense as the domain is no longer registered / free for registration.
Additionally, the complete set of regular expressions were added to the `RegexTK` parser for email, fax, phone, etc.