### PR TITLE
Fixed querying for domain with subdomains

### DIFF
--- a/asyncwhois/pywhois.py
+++ b/asyncwhois/pywhois.py
@@ -72,9 +72,9 @@ class DomainLookup(Lookup):
         # get the WHOIS server associated with this TLD
         server = _self._get_server_name(top_level_domain)
         # submit the WHOIS query to the server
-        hostname = _self.tld_extract_result.domain + "." + top_level_domain
+        registered_domain = _self.tld_extract_result.registered_domain
         query = DomainQuery.new(
-            hostname, server, authoritative_only, proxy_url, timeout
+            registered_domain, server, authoritative_only, proxy_url, timeout
         )
         # parse the raw text output from the WHOIS server
         parser.parse(query.query_output)

--- a/tests/test_package_methods.py
+++ b/tests/test_package_methods.py
@@ -3,6 +3,7 @@ import sys
 import unittest.mock as mock
 
 import asyncwhois
+from asyncwhois.servers import CountryCodeTLD
 import pytest
 
 
@@ -60,3 +61,18 @@ def test_lookup(mock_whois_domain):
     assert f"domain name: {test_domain_name}" in result.query_output.lower(), \
         f"domain name: {test_domain_name} not in {result.query_output.lower()}"
     assert result.parser_output.get('domain_name').lower() == test_domain_name
+
+
+def test_input_parameters_for_domain_query(mocker):
+    spy = mocker.spy(asyncwhois.query.DomainQuery, 'new')
+    mocker.patch(
+        'asyncwhois.query.DomainQuery._do_query',
+        return_value=mock_query_data.get('query_output')
+    )
+
+    test_subdomain_name = 'example.org.ua'
+
+    _ = asyncwhois.whois_domain(test_subdomain_name)
+    call_args = spy.call_args_list[0][0]
+    assert call_args[0] == test_subdomain_name
+    assert call_args[1] == CountryCodeTLD.UA


### PR DESCRIPTION
Fixed fails with domains with subdomains such like this: example.kiev.ua