### PR TITLE
Release 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/asyncwhois.svg)](https://badge.fury.io/py/asyncwhois)
 ![build-workflow](https://github.com/pogzyb/asyncwhois/actions/workflows/build-and-test.yml/badge.svg)
-[![codecov](https://codecov.io/gh/pogzyb/asyncwhois/branch/master/graph/badge.svg?token=Q4xtgezXGX)](https://codecov.io/gh/pogzyb/asyncwhois)
+[![codecov](https://codecov.io/gh/pogzyb/asyncwhois/branch/main/graph/badge.svg?token=Q4xtgezXGX)](https://codecov.io/gh/pogzyb/asyncwhois)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 `asyncwhois` | Async-friendly Python library for WHOIS and RDAP queries.

--- a/asyncwhois/__init__.py
+++ b/asyncwhois/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
     "whois_ipv4",
     "whois_ipv6",
 ]
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 
 def whois_domain(


### PR DESCRIPTION
Highlights:
- #49 : use `registered_domain` for more robust subdomain/domain parsing
- #50 : minor tweaks to .JP regex, .TV root server name, whois server formatting