### PR TITLE
Release/v1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/gh/pogzyb/asyncwhois/branch/main/graph/badge.svg?token=Q4xtgezXGX)](https://codecov.io/gh/pogzyb/asyncwhois)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-`asyncwhois` | Python utility for querying and parsing WHOIS information for Domains, IPv4s, IPv6s, and AS numbers.
+`asyncwhois` | Python utility for WHOIS and RDAP queries.
 
 #### Quickstart
 

--- a/asyncwhois/__init__.py
+++ b/asyncwhois/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
     "whois_ipv4",
     "whois_ipv6",
 ]
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 
 
 def whois_domain(

--- a/asyncwhois/parse_tld.py
+++ b/asyncwhois/parse_tld.py
@@ -951,6 +951,7 @@ class RegexIE(TLDParser):
         super().__init__()
         self.update_reg_expressions(self._ie_expressions)
 
+
 class RegexNZ(TLDParser):
     # These don't seem to be valid anymore:
     # _nz_expressions = {


### PR DESCRIPTION
- #68 fixes an issue with finding authoritative servers and adds more coverage for `domain_name` regular expressions.