### PR TITLE
Fix registrar overwrite

### DIFF
--- a/asyncwhois/parse.py
+++ b/asyncwhois/parse.py
@@ -215,7 +215,6 @@ def convert_whodap_keys(parser_output: dict) -> dict:
         TLDBaseKeys.REGISTRANT_STATE,
         TLDBaseKeys.REGISTRANT_COUNTRY,
         TLDBaseKeys.REGISTRANT_ZIPCODE,
-        TLDBaseKeys.REGISTRAR,
         TLDBaseKeys.REGISTRAR_IANA_ID,
         TLDBaseKeys.REGISTRAR_URL,
         TLDBaseKeys.DNSSEC,


### PR DESCRIPTION
The registrar key is not being handled correctly in the `convert_whodap_keys` function:  https://github.com/pogzyb/asyncwhois/pull/65#issuecomment-2170116576