### PR TITLE
Make authoritative server querying optional

### DIFF
--- a/asyncwhois/__init__.py
+++ b/asyncwhois/__init__.py
@@ -52,6 +52,7 @@ def whois(
     proxy_url: str = None,
     timeout: int = 10,
     tldextract_obj: TLDExtract = None,
+    max_depth: int = None,
 ) -> tuple[str, dict]:
     """
     Performs a WHOIS query for the given `search_term`. If `search_term` is or can be cast to an
@@ -89,6 +90,7 @@ def whois(
                 proxy_url=proxy_url,
                 timeout=timeout,
                 tldextract_obj=tldextract_obj,
+                max_depth=max_depth,
             ).whois(search_term)
     else:
         return "", {}
@@ -145,6 +147,7 @@ async def aio_whois(
     proxy_url: str = None,
     timeout: int = 10,
     tldextract_obj: TLDExtract = None,
+    max_depth: int = None,
 ) -> tuple[str, dict]:
     """
     Performs a WHOIS query for the given `search_term`. If `search_term` is or can be cast to an
@@ -182,6 +185,7 @@ async def aio_whois(
                 proxy_url=proxy_url,
                 timeout=timeout,
                 tldextract_obj=tldextract_obj,
+                max_depth=max_depth,
             ).aio_whois(search_term)
     else:
         return "", {}

--- a/asyncwhois/__init__.py
+++ b/asyncwhois/__init__.py
@@ -42,17 +42,17 @@ __all__ = [
     "GeneralError",
     "QueryError",
 ]
-__version__ = "1.1.7"
+__version__ = "1.1.8"
 
 
 def whois(
     search_term: Union[str, ipaddress.IPv4Address, ipaddress.IPv6Address],
-    authoritative_only: bool = False,
+    authoritative_only: bool = False,  # todo: deprecate and remove this argument
+    find_authoritative_server: bool = True,
     ignore_not_found: bool = False,
     proxy_url: str = None,
     timeout: int = 10,
     tldextract_obj: TLDExtract = None,
-    max_depth: int = None,
 ) -> tuple[str, dict]:
     """
     Performs a WHOIS query for the given `search_term`. If `search_term` is or can be cast to an
@@ -60,8 +60,11 @@ def whois(
     otherwise a DNS search is performed.
 
     :param search_term: Any domain, URL, IPv4, or IPv6
-    :param authoritative_only: If False (default), asyncwhois returns the entire WHOIS query chain,
+    :param authoritative_only: DEPRECATED - If False (default), asyncwhois returns the entire WHOIS query chain,
         otherwise if True, only the authoritative response is returned.
+    :param find_authoritative_server: This parameter only applies to domain queries. If True (default), asyncwhois
+        will attempt to find the authoritative response, otherwise if False, asyncwhois will only query the whois server
+        associated with the given TLD as specified in the IANA root db (`asyncwhois/servers/domains.py`).
     :param ignore_not_found:  If False (default), the `NotFoundError` exception is raised if the query output
         contains "no such domain" language. If True, asyncwhois will not raise `NotFoundError` exceptions.
     :param proxy_url: Optional SOCKS4 or SOCKS5 proxy url (e.g. 'socks5://host:port')
@@ -86,11 +89,11 @@ def whois(
         except (ipaddress.AddressValueError, ValueError):
             return DomainClient(
                 authoritative_only=authoritative_only,
+                find_authoritative_server=find_authoritative_server,
                 ignore_not_found=ignore_not_found,
                 proxy_url=proxy_url,
                 timeout=timeout,
                 tldextract_obj=tldextract_obj,
-                max_depth=max_depth,
             ).whois(search_term)
     else:
         return "", {}
@@ -142,12 +145,12 @@ def rdap(
 
 async def aio_whois(
     search_term: str,
-    authoritative_only: bool = False,
+    authoritative_only: bool = False,  # todo: deprecate and remove this argument
+    find_authoritative_server: bool = True,
     ignore_not_found: bool = False,
     proxy_url: str = None,
     timeout: int = 10,
     tldextract_obj: TLDExtract = None,
-    max_depth: int = None,
 ) -> tuple[str, dict]:
     """
     Performs a WHOIS query for the given `search_term`. If `search_term` is or can be cast to an
@@ -155,8 +158,11 @@ async def aio_whois(
     otherwise a DNS search is performed.
 
     :param search_term: Any domain, URL, IPv4, or IPv6
-    :param authoritative_only: If False (default), asyncwhois returns the entire WHOIS query chain,
+    :param authoritative_only: DEPRECATED - If False (default), asyncwhois returns the entire WHOIS query chain,
         otherwise if True, only the authoritative response is returned.
+    :param find_authoritative_server: This parameter only applies to domain queries. If True (default), asyncwhois
+        will attempt to find the authoritative response, otherwise if False, asyncwhois will only query the whois server
+        associated with the given TLD as specified in the IANA root db (`asyncwhois/servers/domains.py`).
     :param ignore_not_found:  If False (default), the `NotFoundError` exception is raised if the query output
         contains "no such domain" language. If True, asyncwhois will not raise `NotFoundError` exceptions.
     :param proxy_url: Optional SOCKS4 or SOCKS5 proxy url (e.g. 'socks5://host:port')
@@ -185,7 +191,7 @@ async def aio_whois(
                 proxy_url=proxy_url,
                 timeout=timeout,
                 tldextract_obj=tldextract_obj,
-                max_depth=max_depth,
+                find_authoritative_server=find_authoritative_server,
             ).aio_whois(search_term)
     else:
         return "", {}

--- a/asyncwhois/client.py
+++ b/asyncwhois/client.py
@@ -54,6 +54,7 @@ class DomainClient(Client):
         whodap_client: whodap.DNSClient = None,
         timeout: int = 10,
         tldextract_obj: TLDExtract = None,
+        max_depth: int = None,
     ):
         super().__init__(whodap_client)
         self.authoritative_only = authoritative_only
@@ -61,7 +62,7 @@ class DomainClient(Client):
         self.proxy_url = proxy_url
         self.timeout = timeout
         self.tldextract_obj = tldextract_obj
-        self.query_obj = DomainQuery(proxy_url=proxy_url, timeout=timeout)
+        self.query_obj = DomainQuery(proxy_url=proxy_url, timeout=timeout, max_depth=max_depth)
         self.parse_obj = DomainParser(ignore_not_found=ignore_not_found)
 
     def _get_domain_components(self, domain: str) -> tuple[str, str, str]:

--- a/asyncwhois/client.py
+++ b/asyncwhois/client.py
@@ -49,12 +49,12 @@ class DomainClient(Client):
     def __init__(
         self,
         authoritative_only: bool = False,
+        find_authoritative_server: bool = True,
         ignore_not_found: bool = False,
         proxy_url: str = None,
         whodap_client: whodap.DNSClient = None,
         timeout: int = 10,
         tldextract_obj: TLDExtract = None,
-        max_depth: int = None,
     ):
         super().__init__(whodap_client)
         self.authoritative_only = authoritative_only
@@ -62,7 +62,11 @@ class DomainClient(Client):
         self.proxy_url = proxy_url
         self.timeout = timeout
         self.tldextract_obj = tldextract_obj
-        self.query_obj = DomainQuery(proxy_url=proxy_url, timeout=timeout, max_depth=max_depth)
+        self.query_obj = DomainQuery(
+            proxy_url=proxy_url,
+            timeout=timeout,
+            find_authoritative_server=find_authoritative_server,
+        )
         self.parse_obj = DomainParser(ignore_not_found=ignore_not_found)
 
     def _get_domain_components(self, domain: str) -> tuple[str, str, str]:

--- a/asyncwhois/query.py
+++ b/asyncwhois/query.py
@@ -171,7 +171,7 @@ class Query:
         return chain
 
     async def _aio_do_query(
-        self, server: str, data: str, regex: str, chain: list[str], depth: int = 0
+        self, server: str, data: str, regex: str, chain: list[str]
     ) -> list[str]:
         # connect to whois://<server>:43
         async with self._aio_create_connection(

--- a/asyncwhois/query.py
+++ b/asyncwhois/query.py
@@ -23,6 +23,7 @@ class Query:
         self.proxy_url = proxy_url
         self.timeout = timeout
         self.max_depth = max_depth
+        
     @staticmethod
     def _find_match(regex: str, blob: str) -> str:
         match = ""


### PR DESCRIPTION
Addresses the discussion on #98 . Specifically, you can now set `find_authoritative_server=False` to avoid "extra" queries to the authoritative server for a given domain. 