### PR TITLE
Add py.typed marker for PEP 561 type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Security",
     "Framework :: AsyncIO",
+    "Typing :: Typed",
 ]
 dynamic = ["version"]
 license = {text = "MIT License"}


### PR DESCRIPTION
## Summary

Add the PEP 561 marker so static type checkers recognize asyncwhois's existing inline annotations.

## Changes

- Add an empty `asyncwhois/py.typed` marker.
- Add the standard `Typing :: Typed` package classifier.

## Validation

- `uvx --from build pyproject-build` (confirmed the marker is present in both the wheel and source distribution)
- `uvx tox -e py312` (58 passed, 2 skipped)
- Clean-wheel strict mypy checks with versions 1.19.1 and 2.3.0 (both passed and resolved `aio_whois` to its annotated coroutine signature)
- `uvx --python 3.12 black --check asyncwhois` (reports 2 pre-existing formatting differences in unchanged files; the upstream lint workflow is already failing on `main`)

## Compatibility

This is packaging metadata only and does not change runtime behavior or the public API.

Closes #113
